### PR TITLE
Add Description of ID and Password for Demo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ We provide the guide for the installation and how to use it. Please refer the **
 ## Demo site
 You can experience FOSSLight through the **[Demo site](https://demo.fosslight.org/)**.  
 Please visit the Demo site and try out the many features of the FOSSLight first-hand!
+ID and Password for Demo site are described in **[FOSSLight guide](https://fosslight.org/fosslight-guide-en/)**.
 
 ## Contributing
 We always welcome your contributions. Please see the [CONTRIBUTING guide](CONTRIBUTING.md) for how to contribute.


### PR DESCRIPTION
This changes only README.md

## Description

I think that README should have Description of ID and Password for Demo site. 

## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
